### PR TITLE
Update operator hierarchy

### DIFF
--- a/amg/CMakeLists.txt
+++ b/amg/CMakeLists.txt
@@ -49,7 +49,7 @@ set(MESH_DIR ${HOME_DIR}/meshes)
 # TODO: no C++11 in SAAMGe
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -fstack-protector-all")
 set(CMAKE_CXX_FLAGS_OPTIMIZED "${CMAKE_CXX_FLAGS_OPTIMIZED} -O3")
 
 # TODO: take TPLs from command line to override below locations if desired
@@ -96,7 +96,7 @@ list(APPEND TPL_LIBRARIES ${MFEM_LIBRARY_PATH}/${MFEM_LIB_NAME})
 
 # Metis
 find_path(METIS_INCLUDE_PATH metis.h
-  HINTS ${METIS_DIR} ${METIS_DIR}/Lib $ENV{METIS_DIR}/include)
+  HINTS ${METIS_DIR} ${METIS_DIR}/Lib ${METIS_DIR}/include $ENV{METIS_DIR}/include)
 set(METIS_LIB_NAME libmetis.a)
 find_path(METIS_LIBRARY_PATH ${METIS_LIB_NAME}
   HINTS ${METIS_DIR}/lib ${METIS_DIR} $ENV{METIS_DIR}/lib)
@@ -107,15 +107,14 @@ list(APPEND TPL_LIBRARIES ${METIS_LIBRARY_PATH}/${METIS_LIB_NAME})
 
 # Hypre
 find_path(HYPRE_INCLUDE_PATH HYPRE.h
-          HINTS
-            ${HYPRE_DIR}/include
-            $ENV{HYPRE_DIR}/include)
+          HINTS ${HYPRE_DIR}/include $ENV{HYPRE_DIR}/include)
 include_directories(${HYPRE_INCLUDE_PATH})
 set(HYPRE_LIB_NAME libHYPRE.a)
-find_library(HYPRE_LIB HYPRE
-  ${HYPRE_DIR}/lib
-  $ENV{HYPRE_DIR}/lib)
-list(APPEND TPL_LIBRARIES ${HYPRE_LIB})
+find_path(HYPRE_LIBRARY_PATH ${HYPRE_LIB_NAME}
+          HINTS  ${HYPRE_DIR}/lib $ENV{HYPRE_DIR}/lib)
+add_library(HYPRE_LIB STATIC IMPORTED)
+set_property(TARGET HYPRE_LIB PROPERTY IMPORTED_LOCATION ${HYPRE_LIBRARY_PATH}/${HYPRE_LIB_NAME})
+list(APPEND TPL_LIBRARIES ${HYPRE_LIBRARY_PATH}/${HYPRE_LIB_NAME})
 
 # NETCDF - we do not actually use, but might link for MFEM
 option(LINK_NETCDF "Should we link to NETCDF?" OFF)

--- a/amg/CMakeLists.txt
+++ b/amg/CMakeLists.txt
@@ -197,7 +197,7 @@ set_tests_properties(mltest
 
 add_test(pmltest
   mpirun -n 2 test/mltest -m ${PROJECT_SOURCE_DIR}/test/mltest.mesh --num-levels 2 --no-visualization --no-correct-nulspace)
-set_tests_properties(mltest
+set_tests_properties(pmltest
   PROPERTIES
   PASS_REGULAR_EXPRESSION
   "Outer PCG converged in 3 iterations.")
@@ -215,6 +215,13 @@ set_tests_properties(threelevel
   PROPERTIES
   PASS_REGULAR_EXPRESSION
   "Outer PCG converged in 3 iterations.")
+
+add_test(threeleveladapt
+  test/mltest --generate-mesh 100 --num-levels 3 --no-visualization --no-correct-nulspace -ad)
+set_tests_properties(threeleveladapt
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION
+  "Outer PCG converged in 12 iterations.")
 
 add_test(elasticity
   test/mltest -m ${PROJECT_SOURCE_DIR}/test/mltest.mesh --num-levels 2 --no-visualization

--- a/amg/inc/adapt.hpp
+++ b/amg/inc/adapt.hpp
@@ -37,6 +37,7 @@
 #include "common.hpp"
 #include <mfem.hpp>
 #include "tg.hpp"
+#include "ml.hpp"
 
 /* Defines */
 /*! \def ADAPT_XBAD_MAX_ITER_FLAG
@@ -126,6 +127,31 @@ int adapt_approx_xbad(
     tg_data_t *tg_data, mfem::HypreParVector& xbad, double *cf, double *acf,
     double *err, double *err0, int *executed_iters, double rtol/*=10e-12*/, double atol/*=10e-24*/,
     bool normalize/*=1*/, bool output=true);
+
+/*! \brief Updates operators and relaxation.
+
+    It updates the weighted l1-smoother in accordance to the new matrix \a A.
+    This effectively results in adapted smoothers in the TG cycle.
+
+    If \a resmooth_interp is \em true, then the old tentative
+    interpolant will be smoothed with the updated smoother. This changes the
+    hierarchy. Otherwise, the old hierarchy stays untouched.
+    The coarse operator is always freed.
+*/
+void adapt_update_operators(mfem::HypreParMatrix& A, tg_data_t &tg_data, bool resmooth_interp);
+
+/*! \brief Updates operators and relaxation.
+
+    It updates the weghted l1-smoothers in accordance to the new matrix \a A.
+    This effectively results in adapted smoothers in the ML cycle.
+    It also updates the hierarchy of operators.
+
+    If \a resmooth_interp is \em true, then the old tentative
+    interpolants will be smoothed with the updated smoothers. This changes the
+    hierarchy.
+*/
+void adapt_update_operators(mfem::HypreParMatrix& A, ml_data_t &ml_data,
+                            const MultilevelParameters &mlp, bool resmooth_interp);
 
 }
 

--- a/amg/inc/adapt.hpp
+++ b/amg/inc/adapt.hpp
@@ -128,27 +128,30 @@ int adapt_approx_xbad(
     double *err, double *err0, int *executed_iters, double rtol/*=10e-12*/, double atol/*=10e-24*/,
     bool normalize/*=1*/, bool output=true);
 
-/*! \brief Updates operators and relaxation.
+/*! \brief Recomputes hierarchy while assuming spectral information is the same.
 
-    It updates the weighted l1-smoother in accordance to the new matrix \a A.
+    1. It updates the weighted l1-smoother in accordance to the new matrix \a A.
     This effectively results in adapted smoothers in the TG cycle.
+    2. Deletes the coarse operator, so it can be updated, when needed, with a fresh
+    RAP.
 
-    If \a resmooth_interp is \em true, then the old tentative
-    interpolant will be smoothed with the updated smoother. This changes the
-    hierarchy. Otherwise, the old hierarchy stays untouched.
-    The coarse operator is always freed.
+    If \a resmooth_interp is \em true, then the oridinal tentative
+    interpolant will be maintained but resmoothed with the updated smoother.
+    This changes the final interpolant. Otherwise, the original interpolant remains
+    untouched.
 */
 void adapt_update_operators(mfem::HypreParMatrix& A, tg_data_t &tg_data, bool resmooth_interp);
 
-/*! \brief Updates operators and relaxation.
+/*! \brief Recomputes hierarchy while assuming spectral information is the same.
 
-    It updates the weghted l1-smoothers in accordance to the new matrix \a A.
+    1. It updates the weghted l1-smoothers in accordance to the new matrix \a A.
     This effectively results in adapted smoothers in the ML cycle.
-    It also updates the hierarchy of operators.
+    2. It also updates the hierarchy of operators by performing fresh RAPs.
 
-    If \a resmooth_interp is \em true, then the old tentative
-    interpolants will be smoothed with the updated smoothers. This changes the
-    hierarchy.
+    If \a resmooth_interp is \em true, then the original tentative
+    interpolants will be maintained but resmoothed with the updated smoothers.
+    This changes the final interpolants. Otherwise, the original interpolants remain
+    untouched.
 */
 void adapt_update_operators(mfem::HypreParMatrix& A, ml_data_t &ml_data,
                             const MultilevelParameters &mlp, bool resmooth_interp);

--- a/amg/inc/solve.hpp
+++ b/amg/inc/solve.hpp
@@ -104,7 +104,7 @@ private:
 class AMGSolver : public mfem::Solver
 {
 public:
-    AMGSolver(mfem::HypreParMatrix& A, bool iterative_mode);
+    AMGSolver(mfem::HypreParMatrix& A, bool iterative_mode, double rel_tol=1e-12, int iters_coeff=10);
     ~AMGSolver();
     virtual void SetOperator(const mfem::Operator &op) {};
     virtual void Mult(const mfem::Vector &x, mfem::Vector &y) const;
@@ -115,7 +115,7 @@ private:
     double rel_tol;
     mutable int cumulative_iterations; 
     int ref_cntr; /*!< Reference counter. @todo remove */
-    double iters_coeff; /*!< multiply by matrix size for max iterations */
+    int iters_coeff; /*!< multiply by matrix size for max iterations */
 };
 
 /**

--- a/amg/inc/tg.hpp
+++ b/amg/inc/tg.hpp
@@ -757,7 +757,8 @@ void tg_print_data(mfem::HypreParMatrix& A, const tg_data_t *tg_data)
     SA_ASSERT(A.GetGlobalNumRows() ==  A.GetGlobalNumCols());
     SA_ASSERT(tg_data->interp->GetGlobalNumRows() == A.GetGlobalNumRows());
     PROC_STR_STREAM << "Level 1 dimension: "
-                    << (tg_data->Ac?tg_data->Ac->GetGlobalNumCols():tg_data->interp->GetGlobalNumCols());
+                    << (tg_data->Ac ? tg_data->Ac->GetGlobalNumCols() :
+                                      tg_data->interp->GetGlobalNumCols());
     if (tg_data->Ac)
     {
         PROC_STR_STREAM << ", Operator nnz: " << tg_data->Ac->NNZ() << "\n";

--- a/amg/inc/tg.hpp
+++ b/amg/inc/tg.hpp
@@ -771,12 +771,11 @@ void tg_update_coarse_operator(mfem::HypreParMatrix& A, tg_data_t *tg_data,
 static inline
 void tg_free_coarse_operator(tg_data_t& tg_data)
 {
-    SA_ASSERT(&tg_data);
-
     if (!tg_data.Ac)
         return;
 
     delete tg_data.coarse_solver;
+    tg_data.coarse_solver = NULL;
 
     delete tg_data.Ac;
     tg_data.Ac = NULL;
@@ -792,10 +791,10 @@ void tg_print_data(mfem::HypreParMatrix& A, const tg_data_t *tg_data)
               A.NNZ());
     SA_ASSERT(tg_data);
     SA_ASSERT(tg_data->interp);
-    SA_ASSERT( A.GetGlobalNumRows() ==  A.GetGlobalNumCols());
+    SA_ASSERT(A.GetGlobalNumRows() ==  A.GetGlobalNumCols());
     SA_ASSERT(tg_data->interp->GetGlobalNumRows() == A.GetGlobalNumRows());
     PROC_STR_STREAM << "Level 1 dimension: "
-                    << tg_data->interp->GetGlobalNumCols();
+                    << (tg_data->Ac?tg_data->Ac->GetGlobalNumCols():tg_data->interp->GetGlobalNumCols());
     if (tg_data->Ac)
     {
         PROC_STR_STREAM << ", Operator nnz: " << tg_data->Ac->NNZ() << "\n";

--- a/amg/inc/tg.hpp
+++ b/amg/inc/tg.hpp
@@ -592,6 +592,25 @@ tg_data_t *tg_copy_data(const tg_data_t *src);
 
 double tg_compute_OC(mfem::HypreParMatrix& A, tg_data_t& tg_data);
 
+/*! \brief \em Ac is updated (recomputed).
+
+    The previous one is freed and a new one is computed. Also, the "coarse
+    solver" is initialized in case \a perform_solve_init is \em true and
+    \a tg_data->coarse_solver.solve_init is not \em NULL.
+
+    \param A (IN) The fine-grid operator.
+    \param tg_data (IN) The TG data.
+    \param perform_solve_init (IN) Whether to initialize the "coarse solver".
+                                   Unless specially needed, this is usually
+                                   \em true.
+    \param coarse_direct (IN) Use a direct solver on the coarse level.
+
+    \warning \em Ac must be freed using \b tg_free_coarse_operator.
+*/
+void tg_update_coarse_operator(mfem::HypreParMatrix& A, tg_data_t *tg_data,
+                               bool perform_solve_init,
+                               bool coarse_direct);
+
 /* Inline Functions */
 /*! \brief Smooths the tentative interpolant to produce the final one.
 
@@ -636,26 +655,6 @@ mfem::HypreParMatrix *tg_coarse_matr(mfem::HypreParMatrix& A, mfem::HypreParMatr
 static inline
 void tg_fillin_coarse_operator(mfem::HypreParMatrix& A, tg_data_t *tg_data,
                                bool perform_solve_init/*=true*/);
-
-/*! \brief \em Ac is updated (recomputed).
-
-    The previous one is freed and a new one is computed. Also, the "coarse
-    solver" is initialized in case \a perform_solve_init is \em true and
-    \a tg_data->coarse_solver.solve_init is not \em NULL.
-
-    \param A (IN) The fine-grid operator.
-    \param tg_data (IN) The TG data.
-    \param perform_solve_init (IN) Whether to initialize the "coarse solver".
-                                   Unless specially needed, this is usually
-                                   \em true.
-    \param coarse_direct (IN) Use a direct solver on the coarse level.
-
-    \warning \em Ac must be freed using \b tg_free_coarse_operator.
-*/
-static inline
-void tg_update_coarse_operator(mfem::HypreParMatrix& A, tg_data_t *tg_data,
-                               bool perform_solve_init,
-                               bool coarse_direct);
 
 /*! \brief \em Ac is freed.
 
@@ -726,42 +725,6 @@ void tg_fillin_coarse_operator(mfem::HypreParMatrix& A, tg_data_t *tg_data,
                          "Setting coarse solver as a single BoomerAMG v-cycle.\n");
             mfem::HypreBoomerAMG * hbamg =
                 new mfem::HypreBoomerAMG(*tg_data->Ac);
-            hbamg->SetPrintLevel(0);
-            tg_data->coarse_solver = hbamg;
-        }
-    }
-}
-
-static inline
-void tg_update_coarse_operator(mfem::HypreParMatrix& A, tg_data_t *tg_data,
-                               bool perform_solve_init, bool coarse_direct)
-{
-    SA_ASSERT(tg_data);
-    SA_ASSERT(tg_data->interp);
-    SA_ASSERT(tg_data->restr);
-
-    tg_free_coarse_operator(*tg_data);
-    delete tg_data->coarse_solver;
-
-    tg_data->Ac = tg_coarse_matr(A, *(tg_data->interp));
-    if (perform_solve_init)
-    {
-        /*
-        SA_RPRINTF(0,"%s","Setting coarse solver as a CG preconditioned "
-                   "with BoomerAMG.\n");
-        tg_data->coarse_solver = new AMGSolver(*tg_data->Ac, false);
-        */
-        if (coarse_direct)
-        {
-            SA_RPRINTF_L(0, 5, "%s",
-                         "Setting coarse solver as direct UMFPACK solver.\n");
-            tg_data->coarse_solver = new HypreDirect(*tg_data->Ac);
-        }
-        else
-        {
-            SA_RPRINTF_L(0, 5, "%s",
-                       "Setting coarse solver as a single BoomerAMG v-cycle.\n");
-            mfem::HypreBoomerAMG * hbamg = new mfem::HypreBoomerAMG(*tg_data->Ac);
             hbamg->SetPrintLevel(0);
             tg_data->coarse_solver = hbamg;
         }

--- a/amg/src/solve.cpp
+++ b/amg/src/solve.cpp
@@ -237,10 +237,10 @@ void solve_empty(HypreParMatrix& A, HypreParVector& b, HypreParVector& x,
 
 
 // Arguably this is more like SetOperator than a constructor...
-AMGSolver::AMGSolver(HypreParMatrix& A, bool iterative_mode) :
+AMGSolver::AMGSolver(HypreParMatrix& A, bool iterative_mode, double rel_tol, int iters_coeff) :
     mfem::Solver(A.M(), iterative_mode),
-    rel_tol(1.e-12),
-    iters_coeff(10)
+    rel_tol(rel_tol),
+    iters_coeff(iters_coeff)
 {
     SA_RPRINTF(0,"solve_spd_AMG_init() runs with size %d\n", A.M());
 


### PR DESCRIPTION
This is addressing issue #4  open by Chak @chakshinglee . It addresses the operator update. This includes updating the operator hierarchy and the relaxation procedures. It also can resmooth the tentative prolongator respecting the new matrix.